### PR TITLE
rename to galleybytes

### DIFF
--- a/.github/workflows/test-chart-releaser-actions.yml
+++ b/.github/workflows/test-chart-releaser-actions.yml
@@ -20,6 +20,6 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: isaaguilar/chart-releaser-action@v1.1.0-7773ce63
+        uses: galleybytes/chart-releaser-action@v1.1.0-7773ce63
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 Once Helm is set up properly, add the repo as follows:
 
 ```console
-$ helm repo add isaaguilar https://isaaguilar.github.io/helm-charts
+$ helm repo add galleybytes https://galleybytes.github.io/helm-charts
 ```
 
-You can then run `helm search repo isaaguilar` to see the charts.
+You can then run `helm search repo galleybytes` to see the charts.
 

--- a/charts/terraform-operator/Chart.yaml
+++ b/charts/terraform-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.9.0-pre3
 description: A Helm chart to deploy the terraform-operator Controller and CRD.
 name: terraform-operator
-version: v0.2.14
+version: 0.2.15

--- a/charts/terraform-operator/README.md
+++ b/charts/terraform-operator/README.md
@@ -1,14 +1,14 @@
 # terraform-operator
 
-![Version: v0.2.14](https://img.shields.io/badge/Version-v0.2.14-informational?style=flat-square) ![AppVersion: v0.9.0-pre3](https://img.shields.io/badge/AppVersion-v0.9.0--pre3-informational?style=flat-square)
+![Version: 0.2.15](https://img.shields.io/badge/Version-0.2.15-informational?style=flat-square) ![AppVersion: v0.9.0-pre3](https://img.shields.io/badge/AppVersion-v0.9.0--pre3-informational?style=flat-square)
 
 A Helm chart to deploy the terraform-operator Controller and CRD.
 
 ## TL;DR;
 
 ```console
-$ helm repo add isaaguilar https://isaaguilar.github.io/helm-charts
-$ helm install isaaguilar/terraform-operator --namespace tf-system
+$ helm repo add galleybytes https://galleybytes.github.io/helm-charts
+$ helm install galleybytes/terraform-operator --namespace tf-system
 ```
 
 ## Upgrading the Custom Resource Definition
@@ -24,7 +24,7 @@ kubectl apply -f crds/terraform.yaml
 | Key | Description | Default |
 |---|---|---|
 | controller.affinity | `object` node/pod affinities | `{}` |
-| controller.args | `list` additional arguments for the command | <a href="values.yaml#L22-L24">values.yaml</a> |
+| controller.args | `list` additional arguments for the command | <a href="values.yaml#L23-L25">values.yaml</a> |
 | controller.enabled | `bool` deploy the terraform-operator controller | `true` |
 | controller.environmentVars | `object` key/value envs | `{}` |
 | controller.image.pullPolicy | `string` Set how kubernetes determines when to pull the docker image. | `"IfNotPresent"` |
@@ -32,6 +32,6 @@ kubectl apply -f crds/terraform.yaml
 | controller.image.tag | `string` tag of the image | `"v0.9.0-pre3"` |
 | controller.nodeSelector | `object` node labels for pod assignment | `{}` |
 | controller.replicaCount | `int` number of replicas | `1` |
-| controller.resources | `object` CPU/Memory request and limit configuration | <a href="values.yaml#L28-L34">values.yaml</a> |
+| controller.resources | `object` CPU/Memory request and limit configuration | <a href="values.yaml#L32-L38">values.yaml</a> |
 | controller.tolerations | `list` List of node taints to tolerate | `[]` |
 | webhook.enabled | `bool` enables the webhook - required most of the time | `true` |

--- a/charts/terraform-operator/hack/README.md.gotmpl
+++ b/charts/terraform-operator/hack/README.md.gotmpl
@@ -8,8 +8,8 @@
 ## TL;DR;
 
 ```console
-$ helm repo add isaaguilar https://isaaguilar.github.io/helm-charts
-$ helm install isaaguilar/terraform-operator --namespace tf-system
+$ helm repo add galleybytes https://galleybytes.github.io/helm-charts
+$ helm install galleybytes/terraform-operator --namespace tf-system
 ```
 
 ## Upgrading the Custom Resource Definition

--- a/charts/terraform-operator/templates/NOTES.txt
+++ b/charts/terraform-operator/templates/NOTES.txt
@@ -2,6 +2,6 @@
 {{ if .Values.controller.enabled }}
 Check logs with the following command:
 
-    kubectl -n {{ .Release.Namespace }} logs -f deploy/terraform-operator
+    kubectl -n {{ .Release.Namespace }} logs -f deploy/{{ .Release.Name }}
 {{ end }}
 ---

--- a/charts/terraform-operator/templates/controller-clusterrole.yaml
+++ b/charts/terraform-operator/templates/controller-clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: terraform-operator
+  name: {{ .Release.Name }}
   labels:
     app: {{ .Chart.Name }}
     chart: {{ template "_chart.label" . }}

--- a/charts/terraform-operator/templates/controller-clusterrolebinding.yaml
+++ b/charts/terraform-operator/templates/controller-clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: terraform-operator
+  name: {{ .Release.Name }}
   labels:
     app: {{ .Chart.Name }}
     chart: {{ template "_chart.label" . }}
@@ -9,9 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
 subjects:
 - kind: ServiceAccount
-  name: terraform-operator
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: terraform-operator
+  name: {{ .Release.Name }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/terraform-operator/templates/controller-deployment.yaml
+++ b/charts/terraform-operator/templates/controller-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: terraform-operator
+  name: {{ .Release.Name }}
   labels:
     app: {{ .Chart.Name }}
     chart: {{ template "_chart.label" . }}
@@ -25,7 +25,7 @@ spec:
         app: {{ .Chart.Name }}
         release: {{ .Release.Name }}
     spec:
-      serviceAccountName: terraform-operator
+      serviceAccountName: {{ .Release.Name }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001

--- a/charts/terraform-operator/templates/controller-serviceaccount.yaml
+++ b/charts/terraform-operator/templates/controller-serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: terraform-operator
+  name: {{ .Release.Name }}
   labels:
     app: {{ .Chart.Name }}
     chart: {{ template "_chart.label" . }}

--- a/charts/terraform-operator/values.yaml
+++ b/charts/terraform-operator/values.yaml
@@ -19,7 +19,7 @@ controller:
     pullPolicy: IfNotPresent
 
   # controller.args -- additional arguments for the command
-  # @default -- <a href="values.yaml#L22-L24">values.yaml</a>
+  # @default -- <a href="values.yaml#L23-L25">values.yaml</a>
   args:
   - --zap-log-level=debug
   - --zap-encoder=console
@@ -28,7 +28,7 @@ controller:
   # - --max-concurrent-reconciles=10
 
   # controller.resources -- CPU/Memory request and limit configuration
-  # @default -- <a href="values.yaml#L28-L34">values.yaml</a>
+  # @default -- <a href="values.yaml#L32-L38">values.yaml</a>
   resources:
     limits:
       cpu: 50m
@@ -39,7 +39,6 @@ controller:
 
   # controller.environmentVars -- key/value envs
   environmentVars: {}
-    # DOCKERREPO: isaaguilar
 
   # controller.nodeSelector -- node labels for pod assignment
   nodeSelector: {}


### PR DESCRIPTION
- refactor the repo for its not home in galleybytes
- remove the "v" prefix from the chart version
- make the resource names use the {{ .Release.Name }} instead of hard-coded