### PR TITLE
adding toleration config for post job

### DIFF
--- a/charts/terraform-operator-remote-controller/Chart.yaml
+++ b/charts/terraform-operator-remote-controller/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.3.3
+appVersion: 1.4.0
 description: A Helm chart to deploy the terraform-operator-remote-controller
 name: terraform-operator-remote-controller
 version: 1.1.0

--- a/charts/terraform-operator-remote-controller/Chart.yaml
+++ b/charts/terraform-operator-remote-controller/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.3.3
 description: A Helm chart to deploy the terraform-operator-remote-controller
 name: terraform-operator-remote-controller
-version: 1.0.16
+version: 1.1.0

--- a/charts/terraform-operator-remote-controller/templates/configmap.yaml
+++ b/charts/terraform-operator-remote-controller/templates/configmap.yaml
@@ -11,6 +11,12 @@ metadata:
     app.kubernetes.io/managed-by: helm
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 data:
+  {{- if .Values.tolerations }}
+  tolerations: |
+  {{- with .Values.tolerations }}
+  {{- . | toYaml |nindent 4 }}
+  {{- end }}
+  {{- end }}
   {{ if .Values.data.vcluster.enabled }}
   vcluster.tpl.yaml: |-
   {{- if .Values.data.vcluster.prerender }}

--- a/charts/terraform-operator-remote-controller/templates/configmap.yaml
+++ b/charts/terraform-operator-remote-controller/templates/configmap.yaml
@@ -12,7 +12,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 data:
   {{- if .Values.tolerations }}
-  tolerations: |
+  tolerations.yaml: |
   {{- with .Values.tolerations }}
   {{- . | toYaml |nindent 4 }}
   {{- end }}

--- a/charts/terraform-operator-remote-controller/templates/deployment.yaml
+++ b/charts/terraform-operator-remote-controller/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         {{- end }}
         {{- if .Values.tolerations }}
         - name: POST_JOB_TOLERATIONS
-          value: /data/config/tolerations
+          value: /data/config/tolerations.yaml
         {{- end }}
         {{- with .Values.resources }}
         resources:

--- a/charts/terraform-operator-remote-controller/templates/deployment.yaml
+++ b/charts/terraform-operator-remote-controller/templates/deployment.yaml
@@ -42,20 +42,24 @@ spec:
         {{- end }}
         {{- if .Values.data.vcluster.enabled }}
         - name: TFO_API_VCLUSTER_MANIFEST
-          value: /data/vcluster/vcluster.tpl.yaml
+          value: /data/config/vcluster.tpl.yaml
+        {{- end }}
+        {{- if .Values.tolerations }}
+        - name: POST_JOB_TOLERATIONS
+          value: /data/config/tolerations
         {{- end }}
         {{- with .Values.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
-        {{- if .Values.data.vcluster.enabled }}
-        - name: vcluster
-          mountPath: /data/vcluster
+        {{- if or .Values.data.vcluster.enabled .Values.tolerations }}
+        - name: config-volume
+          mountPath: /data/config
         {{- end }}
       volumes:
-      {{- if .Values.data.vcluster.enabled }}
-      - name: vcluster
+      {{- if or .Values.data.vcluster.enabled .Values.tolerations }}
+      - name: config-volume
         configMap:
           name: {{ .Release.Name }}
       {{- end }}

--- a/charts/terraform-operator-remote-controller/values.yaml
+++ b/charts/terraform-operator-remote-controller/values.yaml
@@ -1,7 +1,7 @@
 # -- image repository and tag
 image:
   repository: ghcr.io/galleybytes/terraform-operator-remote-controller
-  tag: 1.3.3
+  tag: 1.4.0
 
 # -- Env defined like k8s EnvVar https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#envvar-v1-core.
 # Values can be tpl ie `{{ .Values.CLIENT_NAME }}` where `CLIENT_NAME` can be defined elsewhere.


### PR DESCRIPTION
Chart was tested with a local build of: https://github.com/GalleyBytes/terraform-operator-remote-controller/pull/13

I opted to use the same tolerations as the deployment but I realize there may be environments where you may want the tforc-post pods to have different tolerations then the terraform-remote-controller. Let me know if you'd like seperate toleration values 